### PR TITLE
fix(traefik): retry middleware + health check for FundingFindr

### DIFF
--- a/hosts/alastor/configuration.nix
+++ b/hosts/alastor/configuration.nix
@@ -857,7 +857,7 @@
             rule = "Host(`fundingfindr.co`)";
             entryPoints = [ "websecure" ];
             tls.certResolver = "cloudflare";
-            middlewares = [ "hsts" ];
+            middlewares = [ "hsts" "ff-retry" ];
             service = "funding-findr";
           };
           # Ollama embedding server on dippet (Mac mini) via Tailscale
@@ -885,6 +885,12 @@
           crane-strip-ext.stripPrefix.prefixes = [ "/ext" ];
           crane-strip-ubo.stripPrefix.prefixes = [ "/ubo" ];
           ollama-auth.basicAuth.usersFile = config.age.secrets.ollama-basicauth.path;
+          # Retry once on 502/503 during Puma phased restarts — absorbs
+          # the brief window while a worker is cycling.
+          ff-retry.retry = {
+            attempts = 2;
+            initialInterval = "100ms";
+          };
         };
         services = {
           knot.loadBalancer.servers = [ { url = "http://127.0.0.1:5555"; } ];
@@ -906,7 +912,14 @@
           crane-memory.loadBalancer.servers = [ { url = "http://127.0.0.1:9005"; } ];
           # Dummy backend for the redirect router (never actually contacted)
           crane-noop.loadBalancer.servers = [ { url = "http://127.0.0.1:1"; } ];
-          funding-findr.loadBalancer.servers = [ { url = "http://127.0.0.1:3300"; } ];
+          funding-findr.loadBalancer = {
+            servers = [ { url = "http://127.0.0.1:3300"; } ];
+            healthCheck = {
+              path = "/up";
+              interval = "5s";
+              timeout = "3s";
+            };
+          };
           ollama.loadBalancer.servers = [ { url = "http://dippet.wildebeest-stargazer.ts.net:11434"; } ];
         };
       };

--- a/modules/strapi/default.nix
+++ b/modules/strapi/default.nix
@@ -74,6 +74,7 @@ in
           "NODE_ENV=production"
           "HOST=127.0.0.1"
           "PORT=${toString cfg.port}"
+          "CLIENT_URL=https://fundingfindr.co"
         ];
         ExecStart = "${pkgs.nodejs}/bin/node node_modules/.bin/strapi start";
         Restart = "on-failure";


### PR DESCRIPTION
## Summary

- **`ff-retry` middleware** — retries once (2 attempts total) on 502/503 with 100ms initial backoff. Absorbs any sub-second blip during Puma phased restart.
- **`healthCheck` on funding-findr service** — Traefik polls `/up` every 5s with a 3s timeout. If Puma is unhealthy, Traefik stops routing to it (and the retry won't send traffic to a dead backend).

Companion to [FundingFindr/funding-findr-rails#242](https://github.com/FundingFindr/funding-findr-rails/pull/242) which fixes the Puma-side root cause.

## Deploy

After merging, rebuild alastor:
```bash
ssh alastor "cd ~/dots && git pull && sudo nixos-rebuild switch --flake .#alastor"
```

Dynamic config is hot-reloaded by Traefik, but since this modifies the file-provider content (rendered via Nix), a rebuild is needed to regenerate the TOML.

## Test plan

- [ ] Rebuild alastor, verify Traefik picks up the new middleware (`docker logs` or Traefik dashboard)
- [ ] Deploy ff-core and confirm no 502s during phased restart
- [ ] Verify health check polling in Traefik logs (`GET /up` every 5s)

Relates to FF-236