### PR TITLE
feat(alastor): preview deploys + local Ollama

### DIFF
--- a/hosts/alastor/configuration.nix
+++ b/hosts/alastor/configuration.nix
@@ -8,6 +8,47 @@
   ...
 }:
 
+let
+  # Helper script for managing per-PR preview Traefik routing.
+  # Runs as root (via sudo) to write/delete dynamic config files in
+  # /etc/traefik/conf.d/. Traefik watches that directory and hot-reloads.
+  preview-traefik = pkgs.writeShellScriptBin "preview-traefik" ''
+    set -euo pipefail
+    ACTION="''${1:?Usage: preview-traefik (write <pr> <slug> <port> | delete <pr>)}"
+    PR="''${2:?Missing PR number}"
+
+    case "$ACTION" in
+      write)
+        SLUG="''${3:?Missing slug}"
+        PORT="''${4:?Missing port}"
+        cat > "/etc/traefik/conf.d/preview-pr-''${PR}.toml" <<TOML
+    [http.routers.preview-pr-''${PR}]
+      rule = "Host(\`''${SLUG}.preview.fundingfindr.co\`)"
+      entryPoints = ["websecure"]
+      service = "preview-pr-''${PR}"
+      [http.routers.preview-pr-''${PR}.tls]
+        certResolver = "cloudflare"
+        [[http.routers.preview-pr-''${PR}.tls.domains]]
+          main = "*.preview.fundingfindr.co"
+
+    [http.services.preview-pr-''${PR}.loadBalancer]
+      [[http.services.preview-pr-''${PR}.loadBalancer.servers]]
+        url = "http://127.0.0.1:''${PORT}"
+    TOML
+        echo "Wrote Traefik config for preview PR #''${PR} (''${SLUG} -> :''${PORT})"
+        ;;
+      delete)
+        rm -f "/etc/traefik/conf.d/preview-pr-''${PR}.toml"
+        echo "Removed Traefik config for preview PR #''${PR}"
+        ;;
+      *)
+        echo "Usage: preview-traefik (write <pr> <slug> <port> | delete <pr>)" >&2
+        exit 1
+        ;;
+    esac
+  '';
+in
+
 {
   imports = [
     ./hardware-configuration.nix
@@ -84,6 +125,8 @@
     openssl
     libxml2
     libxslt
+    # Preview deploy helper (writes Traefik dynamic config for per-PR previews)
+    preview-traefik
   ];
 
   # NH - NixOS helper
@@ -196,6 +239,11 @@
         }
         {
           command = "/run/current-system/sw/bin/systemctl restart funding_findr_worker_low";
+          options = [ "NOPASSWD" ];
+        }
+        # Preview deploy helper — writes/deletes Traefik dynamic config files
+        {
+          command = "${preview-traefik}/bin/preview-traefik *";
           options = [ "NOPASSWD" ];
         }
       ];
@@ -313,6 +361,7 @@
       "strings-witcc"
       "docuseal"
       "redis-docuseal"
+      "ollama"
       "docker"
     ];
     remoteHosts = [
@@ -607,6 +656,31 @@
     };
   };
 
+  # Ollama embedding server (nomic-embed-text for FundingFindr semantic search)
+  # Binds to 127.0.0.1:11434 — only accessible from this host
+  # Model data persisted at /var/lib/ollama
+  # After first deploy, pull the model: docker exec ollama ollama pull nomic-embed-text
+  systemd.services.ollama = {
+    description = "Ollama Embedding Server";
+    after = [ "docker.service" "network.target" ];
+    requires = [ "docker.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "simple";
+      ExecStartPre = [
+        "-${pkgs.docker}/bin/docker stop ollama"
+        "-${pkgs.docker}/bin/docker rm ollama"
+      ];
+      ExecStart = "${pkgs.docker}/bin/docker run --name ollama -p 127.0.0.1:11434:11434 -v /var/lib/ollama:/root/.ollama ollama/ollama";
+      ExecStop = "${pkgs.docker}/bin/docker stop ollama";
+      Restart = "on-failure";
+      RestartSec = "10s";
+      StandardOutput = "journal";
+      StandardError = "journal";
+      SyslogIdentifier = "ollama";
+    };
+  };
+
   # l4 image CDN
   atelier.services.l4 = {
     enable = true;
@@ -860,8 +934,8 @@
             middlewares = [ "hsts" "ff-retry" ];
             service = "funding-findr";
           };
-          # Ollama embedding server on dippet (Mac mini) via Tailscale
-          # BasicAuth protects the endpoint; Rails reads credentials from credentials.yml
+          # Ollama embedding server (local Docker container on port 11434)
+          # BasicAuth protects the public endpoint; Rails reads credentials from credentials.yml
           ollama = {
             rule = "Host(`ollama.hogwarts.dev`)";
             entryPoints = [ "websecure" ];
@@ -920,7 +994,7 @@
               timeout = "3s";
             };
           };
-          ollama.loadBalancer.servers = [ { url = "http://dippet.wildebeest-stargazer.ts.net:11434"; } ];
+          ollama.loadBalancer.servers = [ { url = "http://127.0.0.1:11434"; } ];
         };
       };
     };


### PR DESCRIPTION
## Summary

- **Preview deploys on alastor:** Add `preview-traefik` helper script that writes/deletes per-PR Traefik dynamic config files in `/etc/traefik/conf.d/`. Previews no longer need the Mac Mini or frp tunnels — Traefik routes directly to localhost Puma instances. Includes sudo rule for the `fundingfindr` user.
- **Ollama embeddings local:** Run Ollama as a Docker container on alastor (port 11434) instead of proxying to dippet via Tailscale. Uses `nomic-embed-text` for FundingFindr semantic search. Model data persists at `/var/lib/ollama`. Traefik backend updated from `dippet.wildebeest-stargazer.ts.net:11434` to `127.0.0.1:11434`. BasicAuth middleware unchanged — external API is identical.
- Add `ollama` to status monitoring services list

## Companion PR

**ff-core:** FundingFindr/funding-findr-rails `infra/move-previews-to-alastor` — rewrites preview deploy/cleanup scripts to use `preview-traefik` instead of frpc.

## Deploy steps

1. Merge this PR
2. Rebuild alastor: `ssh alastor 'sudo nixos-rebuild switch --flake /home/jsp/dots#alastor'`
3. Pull the Ollama model (one-time): `ssh alastor 'docker exec ollama ollama pull nomic-embed-text'`
4. Remove old frps catch-all: `ssh alastor 'sudo rm -f /etc/traefik/conf.d/preview-deploys.toml'`
5. Verify Ollama is responding: `curl -u user:pass https://ollama.hogwarts.dev/api/tags`
6. Once confirmed, stop Ollama on dippet

## Test plan

- [ ] `nixos-rebuild switch` completes without errors
- [ ] `systemctl status ollama` shows active
- [ ] `docker exec ollama ollama list` shows `nomic-embed-text`
- [ ] `curl http://localhost:11434/api/tags` returns model list
- [ ] `ollama.hogwarts.dev` still works via Traefik (now hitting localhost)
- [ ] `preview-traefik write 999 test-slug 5999` creates `/etc/traefik/conf.d/preview-pr-999.toml`
- [ ] `preview-traefik delete 999` removes it